### PR TITLE
Allow bref/symfony-messenger ^1.0 and symfony/messenger ^7.0

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -37,7 +37,7 @@ jobs:
           php-version: 8.1
           extensions: apcu, redis
           coverage: none
-          tools: vimeo/psalm:4.22.0
+          tools: vimeo/psalm:4.30.0
 
       - name: Download dependencies
         uses: ramsey/composer-install@v1

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.31",
-        "symfony/validator": "^5.0 || ^6.0",
+        "symfony/validator": "^5.0 || ^6.0 || ^7.0",
         "symfony/polyfill-php80": "^1.17",
         "symfony/event-dispatcher-contracts": "^2.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
     ],
     "require": {
         "php": ">=7.3",
-        "bref/symfony-messenger": "^0.3 || ^0.4 || ^0.5",
+        "bref/symfony-messenger": "^0.3 || ^0.4 || ^0.5 || ^1.0",
         "symfony/messenger": "^4.4 || ^5.0 || ^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     "require": {
         "php": ">=7.3",
         "bref/symfony-messenger": "^0.3 || ^0.4 || ^0.5 || ^1.0",
-        "symfony/messenger": "^4.4 || ^5.0 || ^6.0"
+        "symfony/messenger": "^4.4 || ^5.0 || ^6.0 || ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^8.5.31",


### PR DESCRIPTION
As stated in the release notes https://github.com/brefphp/symfony-messenger/releases/tag/1.0.0

> There are no BC breaks with the previous 0.x version.
> I am tagging 1.0 because this repository is stable and should no longer be a 0.x version.